### PR TITLE
채널 서버에 올라온 백엔드 처리요청 반영

### DIFF
--- a/src/main/java/com/sparkLab/study/constant/FeedbackCommentType.java
+++ b/src/main/java/com/sparkLab/study/constant/FeedbackCommentType.java
@@ -1,0 +1,6 @@
+package com.sparkLab.study.constant;
+
+public enum FeedbackCommentType {
+    MENTEE_QUESTION,
+    MENTOR_REPLY
+}

--- a/src/main/java/com/sparkLab/study/constant/NotificationLinkType.java
+++ b/src/main/java/com/sparkLab/study/constant/NotificationLinkType.java
@@ -1,0 +1,9 @@
+package com.sparkLab.study.constant;
+
+public enum NotificationLinkType {
+    TODO,
+    ASSIGNMENT,
+    FEEDBACK,
+    QUESTION,
+    MENTEE
+}

--- a/src/main/java/com/sparkLab/study/controller/AssignmentSubmissionController.java
+++ b/src/main/java/com/sparkLab/study/controller/AssignmentSubmissionController.java
@@ -1,6 +1,6 @@
 package com.sparkLab.study.controller;
 
-import com.sparkLab.study.dto.assignment.AssignmentSubmissionResponse;
+import com.sparkLab.study.dto.assignment.AssignmentSubmissionBatchResponse;
 import com.sparkLab.study.service.AssignmentSubmissionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -9,6 +9,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("assignments")
@@ -20,10 +22,12 @@ public class AssignmentSubmissionController {
     @PreAuthorize("hasAnyRole('MENTOR','MENTEE')")
     @PostMapping(value = "/{assignmentId}/submissions",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<AssignmentSubmissionResponse> submit(
+    public ResponseEntity<AssignmentSubmissionBatchResponse> submit(
             @PathVariable Long assignmentId,
-            @RequestParam("file") MultipartFile file) {
-        AssignmentSubmissionResponse response = submissionService.submit(assignmentId, file);
+            @RequestParam(value = "file", required = false) MultipartFile file,
+            @RequestParam(value = "files", required = false) List<MultipartFile> files,
+            @RequestParam(value = "comment", required = false) String comment) {
+        AssignmentSubmissionBatchResponse response = submissionService.submit(assignmentId, file, files, comment);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 }

--- a/src/main/java/com/sparkLab/study/controller/FeedbackCommentController.java
+++ b/src/main/java/com/sparkLab/study/controller/FeedbackCommentController.java
@@ -1,0 +1,41 @@
+package com.sparkLab.study.controller;
+
+import com.sparkLab.study.dto.feedback.FeedbackCommentCreateRequest;
+import com.sparkLab.study.dto.feedback.FeedbackCommentResponse;
+import com.sparkLab.study.service.FeedbackCommentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("feedbacks")
+@RequiredArgsConstructor
+public class FeedbackCommentController {
+
+    private final FeedbackCommentService feedbackCommentService;
+
+    @PreAuthorize("hasAnyRole('MENTOR','MENTEE')")
+    @PostMapping("/{feedbackId}/comments")
+    public ResponseEntity<FeedbackCommentResponse> create(
+            @PathVariable Long feedbackId,
+            @RequestBody @Valid FeedbackCommentCreateRequest request) {
+        FeedbackCommentResponse created = feedbackCommentService.create(feedbackId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PreAuthorize("hasAnyRole('MENTOR','MENTEE')")
+    @GetMapping("/{feedbackId}/comments")
+    public List<FeedbackCommentResponse> list(@PathVariable Long feedbackId) {
+        return feedbackCommentService.list(feedbackId);
+    }
+}

--- a/src/main/java/com/sparkLab/study/dto/assignment/AssignmentSubmissionBatchResponse.java
+++ b/src/main/java/com/sparkLab/study/dto/assignment/AssignmentSubmissionBatchResponse.java
@@ -1,0 +1,12 @@
+package com.sparkLab.study.dto.assignment;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AssignmentSubmissionBatchResponse {
+    private List<AssignmentSubmissionResponse> submissions;
+}

--- a/src/main/java/com/sparkLab/study/dto/assignment/AssignmentSubmissionResponse.java
+++ b/src/main/java/com/sparkLab/study/dto/assignment/AssignmentSubmissionResponse.java
@@ -12,6 +12,7 @@ public class AssignmentSubmissionResponse {
     private Long assignmentId;
     private Long menteeId;
     private String imageUrl;
+    private String comment;
     private String status;
     private LocalDateTime createTime;
 }

--- a/src/main/java/com/sparkLab/study/dto/feedback/FeedbackCommentCreateRequest.java
+++ b/src/main/java/com/sparkLab/study/dto/feedback/FeedbackCommentCreateRequest.java
@@ -1,0 +1,18 @@
+package com.sparkLab.study.dto.feedback;
+
+import com.sparkLab.study.constant.FeedbackCommentType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FeedbackCommentCreateRequest {
+
+    @NotNull
+    private FeedbackCommentType type;
+
+    @NotBlank
+    private String content;
+}

--- a/src/main/java/com/sparkLab/study/dto/feedback/FeedbackCommentResponse.java
+++ b/src/main/java/com/sparkLab/study/dto/feedback/FeedbackCommentResponse.java
@@ -1,0 +1,19 @@
+package com.sparkLab.study.dto.feedback;
+
+import com.sparkLab.study.constant.FeedbackCommentType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class FeedbackCommentResponse {
+
+    private Long feedbackCommentId;
+    private Long feedbackId;
+    private FeedbackCommentType type;
+    private String content;
+    private LocalDateTime createTime;
+    private LocalDateTime updateTime;
+}

--- a/src/main/java/com/sparkLab/study/dto/notification/NotificationResponse.java
+++ b/src/main/java/com/sparkLab/study/dto/notification/NotificationResponse.java
@@ -1,5 +1,6 @@
 package com.sparkLab.study.dto.notification;
 
+import com.sparkLab.study.constant.NotificationLinkType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +17,7 @@ public class NotificationResponse {
     private Long notificationId;
     private String type;
     private String title;
-    private String linkType;
+    private NotificationLinkType linkType;
     private Long linkId;
     private Boolean isRead;
     private LocalDateTime createdAt;

--- a/src/main/java/com/sparkLab/study/dto/todo/TodoItemResponse.java
+++ b/src/main/java/com/sparkLab/study/dto/todo/TodoItemResponse.java
@@ -23,6 +23,7 @@ public class TodoItemResponse {
     private String status;
     private Integer plannedMinutes;
     private Integer actualMinutes;
+    private Integer actualSeconds;
     private LocalDateTime completedAt;
     private LocalDateTime createTime;
     private LocalDateTime updateTime;

--- a/src/main/java/com/sparkLab/study/dto/todo/TodoItemUpdateRequest.java
+++ b/src/main/java/com/sparkLab/study/dto/todo/TodoItemUpdateRequest.java
@@ -3,6 +3,7 @@ package com.sparkLab.study.dto.todo;
 import com.sparkLab.study.constant.Subject;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -13,10 +14,12 @@ import java.time.LocalDateTime;
 public class TodoItemUpdateRequest {
 
     private String title;
+    private LocalDate targetDate;
     private Subject subject;
     private String type;
     private String status;
     private Integer plannedMinutes;
     private Integer actualMinutes;
+    private Integer actualSeconds;
     private LocalDateTime completedAt;
 }

--- a/src/main/java/com/sparkLab/study/entity/AssignmentSubmission.java
+++ b/src/main/java/com/sparkLab/study/entity/AssignmentSubmission.java
@@ -24,6 +24,7 @@ public class AssignmentSubmission extends BaseTime{
     private Mentee mentee;
 
     private String imageUrl;
+    private String comment;
     private String status;
 
 }

--- a/src/main/java/com/sparkLab/study/entity/FeedbackComment.java
+++ b/src/main/java/com/sparkLab/study/entity/FeedbackComment.java
@@ -1,0 +1,39 @@
+package com.sparkLab.study.entity;
+
+import com.sparkLab.study.constant.FeedbackCommentType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "feedback_comments")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FeedbackComment extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long feedbackCommentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feedback_id", nullable = false)
+    private Feedback feedback;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private FeedbackCommentType type;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    public static FeedbackComment of(Feedback feedback, FeedbackCommentType type, String content) {
+        FeedbackComment comment = new FeedbackComment();
+        comment.setFeedback(feedback);
+        comment.setType(type);
+        comment.setContent(content);
+        return comment;
+    }
+}

--- a/src/main/java/com/sparkLab/study/entity/Notification.java
+++ b/src/main/java/com/sparkLab/study/entity/Notification.java
@@ -1,5 +1,6 @@
 package com.sparkLab.study.entity;
 
+import com.sparkLab.study.constant.NotificationLinkType;
 import com.sparkLab.study.security.auth.entity.Account;
 import jakarta.persistence.*;
 import lombok.*;
@@ -23,7 +24,8 @@ public class Notification {
 
     private String type;
     private String title;
-    private String linkType;
+    @Enumerated(EnumType.STRING)
+    private NotificationLinkType linkType;
     private Long linkId;
     private Boolean isRead;
     private LocalDateTime createdAt;

--- a/src/main/java/com/sparkLab/study/entity/TodoItem.java
+++ b/src/main/java/com/sparkLab/study/entity/TodoItem.java
@@ -37,6 +37,7 @@ public class TodoItem extends BaseTime{
     private String status;
     private Integer plannedMinutes;
     private Integer actualMinutes;
+    private Integer actualSeconds;
     private LocalDateTime completedAt;
 
     @OneToMany(mappedBy = "todoItem", cascade = CascadeType.ALL)

--- a/src/main/java/com/sparkLab/study/repository/FeedbackCommentRepository.java
+++ b/src/main/java/com/sparkLab/study/repository/FeedbackCommentRepository.java
@@ -1,0 +1,10 @@
+package com.sparkLab.study.repository;
+
+import com.sparkLab.study.entity.FeedbackComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FeedbackCommentRepository extends JpaRepository<FeedbackComment, Long> {
+    List<FeedbackComment> findByFeedback_FeedbackIdOrderByCreateTimeAsc(Long feedbackId);
+}

--- a/src/main/java/com/sparkLab/study/repository/NotificationRepository.java
+++ b/src/main/java/com/sparkLab/study/repository/NotificationRepository.java
@@ -1,6 +1,7 @@
 package com.sparkLab.study.repository;
 
 import com.sparkLab.study.entity.Notification;
+import com.sparkLab.study.constant.NotificationLinkType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
@@ -13,7 +14,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     boolean existsByRecipient_AccountIdAndTypeAndLinkTypeAndLinkIdAndCreatedAtBetween(
             String accountId,
             String type,
-            String linkType,
+            NotificationLinkType linkType,
             Long linkId,
             LocalDateTime start,
             LocalDateTime end

--- a/src/main/java/com/sparkLab/study/service/AssignmentSubmissionService.java
+++ b/src/main/java/com/sparkLab/study/service/AssignmentSubmissionService.java
@@ -1,5 +1,6 @@
 package com.sparkLab.study.service;
 
+import com.sparkLab.study.dto.assignment.AssignmentSubmissionBatchResponse;
 import com.sparkLab.study.dto.assignment.AssignmentSubmissionResponse;
 import com.sparkLab.study.entity.Assignment;
 import com.sparkLab.study.entity.AssignmentSubmission;
@@ -17,6 +18,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
@@ -46,47 +49,77 @@ public class AssignmentSubmissionService {
     private String uploadDir;
 
     @Transactional
-    public AssignmentSubmissionResponse submit(Long assignmentId, MultipartFile file) {
-        validateFile(file);
+    public AssignmentSubmissionBatchResponse submit(
+            Long assignmentId,
+            MultipartFile file,
+            List<MultipartFile> files,
+            String comment
+    ) {
+        List<MultipartFile> uploadTargets = normalizeFiles(file, files);
+        validateFiles(uploadTargets);
 
         Assignment assignment = assignmentRepository.findById(assignmentId)
                 .orElseThrow(() -> new TaskResourceNotFoundException("과제를 찾을 수 없습니다. assignmentId=" + assignmentId));
         if (assignment.getTodoItem() == null || assignment.getTodoItem().getMentee() == null) {
             throw new TaskResourceNotFoundException("과제에 연결된 멘티가 없습니다. assignmentId=" + assignmentId);
         }
-        String extension = getExtension(file.getOriginalFilename());
-        String filename = UUID.randomUUID() + (extension.isEmpty() ? "" : "." + extension);
+        List<AssignmentSubmissionResponse> responses = new ArrayList<>();
         Path uploadPath = Paths.get(uploadDir, "assignments", String.valueOf(assignmentId));
         createDirectories(uploadPath);
 
-        Path targetPath = uploadPath.resolve(filename).normalize();
-        try {
-            Files.copy(file.getInputStream(), targetPath);
-        } catch (IOException e) {
-            throw new IllegalArgumentException("파일 저장에 실패했습니다.");
+        for (MultipartFile uploadFile : uploadTargets) {
+            String extension = getExtension(uploadFile.getOriginalFilename());
+            String filename = UUID.randomUUID() + (extension.isEmpty() ? "" : "." + extension);
+            Path targetPath = uploadPath.resolve(filename).normalize();
+            try {
+                Files.copy(uploadFile.getInputStream(), targetPath);
+            } catch (IOException e) {
+                throw new IllegalArgumentException("파일 저장에 실패했습니다.");
+            }
+
+            String imageUrl = "/uploads/assignments/" + assignmentId + "/" + filename;
+            AssignmentSubmission submission = AssignmentSubmission.builder()
+                    .assignment(assignment)
+                    .mentee(assignment.getTodoItem().getMentee())
+                    .imageUrl(imageUrl)
+                    .comment(comment)
+                    .status("SUBMITTED")
+                    .build();
+            submission = submissionRepository.save(submission);
+            notificationService.notifyMentorAssignmentSubmitted(submission);
+            responses.add(toResponse(submission));
         }
 
-        String imageUrl = "/uploads/assignments/" + assignmentId + "/" + filename;
-        AssignmentSubmission submission = AssignmentSubmission.builder()
-                .assignment(assignment)
-                .mentee(assignment.getTodoItem().getMentee())
-                .imageUrl(imageUrl)
-                .status("SUBMITTED")
+        return AssignmentSubmissionBatchResponse.builder()
+                .submissions(responses)
                 .build();
-        submission = submissionRepository.save(submission);
-        notificationService.notifyMentorAssignmentSubmitted(submission);
-        return toResponse(submission);
     }
 
-    private void validateFile(MultipartFile file) {
-        if (file == null || file.isEmpty()) {
+    private List<MultipartFile> normalizeFiles(MultipartFile file, List<MultipartFile> files) {
+        if (files != null && !files.isEmpty()) {
+            return files;
+        }
+        List<MultipartFile> result = new ArrayList<>();
+        if (file != null) {
+            result.add(file);
+        }
+        return result;
+    }
+
+    private void validateFiles(List<MultipartFile> files) {
+        if (files == null || files.isEmpty()) {
             throw new IllegalArgumentException("제출 파일은 필수입니다.");
         }
-        String contentType = file.getContentType();
-        String extension = getExtension(file.getOriginalFilename());
-        if ((contentType != null && !ALLOWED_CONTENT_TYPES.contains(contentType))
-                && (extension.isEmpty() || !ALLOWED_EXTENSIONS.contains(extension))) {
-            throw new IllegalArgumentException("이미지(jpg/png/gif) 파일만 업로드할 수 있습니다.");
+        for (MultipartFile file : files) {
+            if (file == null || file.isEmpty()) {
+                throw new IllegalArgumentException("제출 파일은 필수입니다.");
+            }
+            String contentType = file.getContentType();
+            String extension = getExtension(file.getOriginalFilename());
+            if ((contentType != null && !ALLOWED_CONTENT_TYPES.contains(contentType))
+                    && (extension.isEmpty() || !ALLOWED_EXTENSIONS.contains(extension))) {
+                throw new IllegalArgumentException("이미지(jpg/png/gif) 파일만 업로드할 수 있습니다.");
+            }
         }
     }
 
@@ -115,6 +148,7 @@ public class AssignmentSubmissionService {
                 .assignmentId(submission.getAssignment().getAssignmentId())
                 .menteeId(submission.getMentee().getMenteeId())
                 .imageUrl(submission.getImageUrl())
+                .comment(submission.getComment())
                 .status(submission.getStatus())
                 .createTime(submission.getCreateTime())
                 .build();

--- a/src/main/java/com/sparkLab/study/service/FeedbackCommentService.java
+++ b/src/main/java/com/sparkLab/study/service/FeedbackCommentService.java
@@ -1,0 +1,50 @@
+package com.sparkLab.study.service;
+
+import com.sparkLab.study.dto.feedback.FeedbackCommentCreateRequest;
+import com.sparkLab.study.dto.feedback.FeedbackCommentResponse;
+import com.sparkLab.study.entity.Feedback;
+import com.sparkLab.study.entity.FeedbackComment;
+import com.sparkLab.study.exception.TaskResourceNotFoundException;
+import com.sparkLab.study.repository.FeedbackCommentRepository;
+import com.sparkLab.study.repository.FeedbackRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackCommentService {
+
+    private final FeedbackRepository feedbackRepository;
+    private final FeedbackCommentRepository feedbackCommentRepository;
+
+    @Transactional
+    public FeedbackCommentResponse create(Long feedbackId, FeedbackCommentCreateRequest request) {
+        Feedback feedback = feedbackRepository.findById(feedbackId)
+                .orElseThrow(() -> new TaskResourceNotFoundException("피드백을 찾을 수 없습니다. feedbackId=" + feedbackId));
+
+        FeedbackComment comment = FeedbackComment.of(feedback, request.getType(), request.getContent());
+        return toResponse(feedbackCommentRepository.save(comment));
+    }
+
+    @Transactional(readOnly = true)
+    public List<FeedbackCommentResponse> list(Long feedbackId) {
+        List<FeedbackComment> comments = feedbackCommentRepository
+                .findByFeedback_FeedbackIdOrderByCreateTimeAsc(feedbackId);
+        return comments.stream().map(this::toResponse).collect(Collectors.toList());
+    }
+
+    private FeedbackCommentResponse toResponse(FeedbackComment comment) {
+        return FeedbackCommentResponse.builder()
+                .feedbackCommentId(comment.getFeedbackCommentId())
+                .feedbackId(comment.getFeedback().getFeedbackId())
+                .type(comment.getType())
+                .content(comment.getContent())
+                .createTime(comment.getCreateTime())
+                .updateTime(comment.getUpdateTime())
+                .build();
+    }
+}

--- a/src/main/java/com/sparkLab/study/service/NotificationService.java
+++ b/src/main/java/com/sparkLab/study/service/NotificationService.java
@@ -1,20 +1,19 @@
 package com.sparkLab.study.service;
 
+import com.sparkLab.study.constant.ActiveLevel;
+import com.sparkLab.study.constant.NotificationLinkType;
 import com.sparkLab.study.dto.notification.NotificationResponse;
 import com.sparkLab.study.security.auth.entity.Account;
-import com.sparkLab.study.constant.ActiveLevel;
 import com.sparkLab.study.entity.Assignment;
 import com.sparkLab.study.entity.AssignmentSubmission;
 import com.sparkLab.study.entity.Feedback;
 import com.sparkLab.study.entity.Mentee;
 import com.sparkLab.study.entity.Mentor;
 import com.sparkLab.study.entity.Notification;
-import com.sparkLab.study.entity.Planner;
 import com.sparkLab.study.entity.TodoItem;
 import com.sparkLab.study.repository.AssignmentRepository;
 import com.sparkLab.study.repository.AssignmentSubmissionRepository;
 import com.sparkLab.study.repository.NotificationRepository;
-import com.sparkLab.study.repository.PlannerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -39,10 +38,11 @@ public class NotificationService {
     private static final String TYPE_MENTEE_WARNING = "MENTEE_WARNING";
     private static final String TYPE_MENTEE_DANGER = "MENTEE_DANGER";
 
-    private static final String LINK_PLANNER = "PLANNER";
-    private static final String LINK_ASSIGNMENT = "ASSIGNMENT";
-    private static final String LINK_MENTEE = "MENTEE";
-    private static final String LINK_QNA = "QNA";
+    private static final NotificationLinkType LINK_TODO = NotificationLinkType.TODO;
+    private static final NotificationLinkType LINK_ASSIGNMENT = NotificationLinkType.ASSIGNMENT;
+    private static final NotificationLinkType LINK_FEEDBACK = NotificationLinkType.FEEDBACK;
+    private static final NotificationLinkType LINK_QUESTION = NotificationLinkType.QUESTION;
+    private static final NotificationLinkType LINK_MENTEE = NotificationLinkType.MENTEE;
     private static final String TITLE_TODO_CREATED =
             "📌 새로운 할 일이 등록되었어요.\n플래너에서 바로 확인해보세요!";
     private static final String TITLE_ASSIGNMENT_DUE_SOON =
@@ -65,7 +65,6 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final AssignmentRepository assignmentRepository;
     private final AssignmentSubmissionRepository submissionRepository;
-    private final PlannerRepository plannerRepository;
 
     @Transactional(readOnly = true)
     public List<NotificationResponse> listByAccount(String accountId) {
@@ -84,9 +83,13 @@ public class NotificationService {
         if (recipient == null) {
             return;
         }
-        Planner planner = todoItem.getPlanner();
-        Long plannerId = planner == null ? null : planner.getPlannerId();
-        createNotification(recipient, TYPE_TODO_CREATED, TITLE_TODO_CREATED, LINK_PLANNER, plannerId);
+        createNotification(
+                recipient,
+                TYPE_TODO_CREATED,
+                TITLE_TODO_CREATED,
+                LINK_TODO,
+                todoItem.getTodoItemId()
+        );
     }
 
     @Transactional
@@ -97,23 +100,21 @@ public class NotificationService {
         }
         TodoItem todoItem = feedback.getTodoItem();
         if (todoItem != null && todoItem.getAssignments() != null && !todoItem.getAssignments().isEmpty()) {
-            Assignment assignment = todoItem.getAssignments().get(0);
             createNotification(
                     mentee.getAccount(),
                     TYPE_ASSIGNMENT_FEEDBACK,
                     TITLE_ASSIGNMENT_FEEDBACK,
-                    LINK_ASSIGNMENT,
-                    assignment.getAssignmentId()
+                    LINK_FEEDBACK,
+                    feedback.getFeedbackId()
             );
             return;
         }
-        Long plannerId = resolvePlannerId(mentee.getMenteeId(), feedback.getTargetDate(), todoItem);
         createNotification(
                 mentee.getAccount(),
                 TYPE_PLANNER_FEEDBACK,
                 TITLE_PLANNER_FEEDBACK,
-                LINK_PLANNER,
-                plannerId
+                LINK_FEEDBACK,
+                feedback.getFeedbackId()
         );
     }
 
@@ -148,7 +149,7 @@ public class NotificationService {
                 recipient,
                 TYPE_MENTOR_QUESTION_CREATED,
                 formatMenteeTitle(TITLE_MENTOR_QUESTION_CREATED, mentee),
-                LINK_QNA,
+                LINK_QUESTION,
                 qnaId
         );
     }
@@ -277,18 +278,6 @@ public class NotificationService {
         }
     }
 
-    private Long resolvePlannerId(Long menteeId, LocalDateTime targetDate, TodoItem todoItem) {
-        if (todoItem != null && todoItem.getPlanner() != null) {
-            return todoItem.getPlanner().getPlannerId();
-        }
-        if (targetDate == null) {
-            return null;
-        }
-        return plannerRepository.findByMentee_MenteeIdAndPlanDate(menteeId, targetDate.toLocalDate())
-                .map(Planner::getPlannerId)
-                .orElse(null);
-    }
-
     private Account resolveMentorAccount(Assignment assignment, Mentee mentee) {
         Mentor mentor = assignment == null ? null : assignment.getMentor();
         if (mentor == null && mentee != null) {
@@ -311,7 +300,7 @@ public class NotificationService {
             Account recipient,
             String type,
             String title,
-            String linkType,
+            NotificationLinkType linkType,
             Long linkId
     ) {
         Notification notification = Notification.builder()

--- a/src/main/java/com/sparkLab/study/service/TodoItemService.java
+++ b/src/main/java/com/sparkLab/study/service/TodoItemService.java
@@ -126,11 +126,13 @@ public class TodoItemService {
 
     private TodoItem applyUpdate(TodoItem todo, TodoItemUpdateRequest request) {
         if (request.getTitle() != null) todo.setTitle(request.getTitle());
+        if (request.getTargetDate() != null) todo.setTargetDate(request.getTargetDate());
         if (request.getSubject() != null) todo.setSubject(request.getSubject());
         if (request.getType() != null) todo.setType(request.getType());
         if (request.getStatus() != null) todo.setStatus(request.getStatus());
         if (request.getPlannedMinutes() != null) todo.setPlannedMinutes(request.getPlannedMinutes());
         if (request.getActualMinutes() != null) todo.setActualMinutes(request.getActualMinutes());
+        if (request.getActualSeconds() != null) todo.setActualSeconds(request.getActualSeconds());
         if (request.getCompletedAt() != null) todo.setCompletedAt(request.getCompletedAt());
         return todo;
     }
@@ -147,6 +149,7 @@ public class TodoItemService {
                 .status(todo.getStatus())
                 .plannedMinutes(todo.getPlannedMinutes())
                 .actualMinutes(todo.getActualMinutes())
+                .actualSeconds(todo.getActualSeconds())
                 .completedAt(todo.getCompletedAt())
                 .createTime(todo.getCreateTime())
                 .updateTime(todo.getUpdateTime())


### PR DESCRIPTION
1. Todo 생성/수정 스펙
  - TodoItemUpdateRequest에 targetDate 추가
  - targerDate에 있는 기존의 actual_minutes에 actual_seconds 까지 추가해서 초단위 시간을 잴 수 있도록 (둘다 null 가능)

2. 과제 제출
  - /assignments/{id}/submissions에 comment 필드 추가
  - 다중 파일을 고려해서 dto 에 SubmissionResponse 와 SubmissionBatchResponse 로 분리 즉 , 제출건이 하나이면 submission 으로 두건 이상이면 batch 로
  
3. 알림
    - linkId가 어떤 리소스 ID인지 명확화
    - Notification.linkType, NotificationResponse.linkType를 enum 타입으로 변경
      알림 생성 시 linkId를 아래 기준으로 통일
      <linkType → linkId 의미>
           -  멘티 알림
              TODO → todoItemId
              ASSIGNMENT → assignmentId (마감 D-1)
              FEEDBACK → feedbackId (과제/플래너 피드백 공통)
           - 멘토 알림
              ASSIGNMENT → assignmentId (과제 제출/미제출)
              QUESTION → qnaId
              MENTEE → menteeId (등급 변경 경고/위험)

4. 피드백 질문 스레드 API (아까 보윤님께서 말씀하신 피드백 상세페이지에 멘토와 멘티 간 질의응답 구현을 위해 필요합니다!)
  - POST /feedbacks/{id}/comments 로 질문/답변을 저장하고, 상세 페이지에서 조회할 수 있도록 GET /feedbacks/{id}/comments도        같이 제공
  - 타입은 MENTEE_QUESTION / MENTOR_REPLY로 분기
  - feedback에 comment/type만 추가하려 했지만 
     - 다건 Q&A 표현 불가: feedback에 단일 comment/type이면 질문·답변이 여러 개일 때 모델이 깨짐
     - 정렬/이력 유지 어려움: 시간순 스레드, 수정 이력, 삭제 처리 모두 불리
     - 권한/주체 분리 불가: 멘토/멘티 작성자 기준 로직을 확장하기 어렵고, 추후 필드 추가 시 빈번한 스키마 변경 유발
    
    다음과 같은 이유로 별도 FeedbackComment 엔티티 분리